### PR TITLE
Add correction for reference contaminated by transient flux

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from ztfphot import read_ztf_lc, ZTF_LC, LC, verify_reference, SN, PlotType
+from ztfphot import read_ztf_lc, ZtfLC, LC, verify_reference, SN, PlotType
 from astropy.table import Table
 import altair as alt
 import numpy as np
@@ -14,9 +14,12 @@ st.write("Open source tool for making and plotting publication quality lightcurv
 
 @st.experimental_memo
 def cached_read(uploaded_file) -> Table:
-    with open('temp.txt', "wb") as outfile:
-        outfile.write(uploaded_file.getvalue())
-    return read_ztf_lc('temp.txt')
+    file_exists = st.session_state.get(uploaded_file.name)
+    if not file_exists:
+        with open(uploaded_file.name, "wb") as outfile:
+            outfile.write(uploaded_file.getvalue())
+        st.session_state[uploaded_file.name] = True
+    return read_ztf_lc(uploaded_file.name)
 
 
 @st.experimental_memo
@@ -33,7 +36,7 @@ snname = st.text_input("SN name: <SN2020xyz> / <ztf20TooLngNm> (Currently only u
 uploaded_file = st.file_uploader('Upload a ZTF forced photometry service file', type=['txt', 'csv'], key='ztffps_file')
 if uploaded_file:
     at = cached_read(uploaded_file)
-    allbands = ZTF_LC(at)
+    allbands = ZtfLC(at)
 
     band = st.radio("ZTF Filter:", ("g", "r", "i"))
     lc = allbands[allbands["filter"] == f"ZTF_{band}"]
@@ -45,7 +48,7 @@ if uploaded_file:
     col1, col2 = st.columns(2)
 
     with col1:
-        options = ["verify references", "photometric", "good seeing",
+        options = ["photometric", "good seeing",
                    "filter procstatus", "rescale uncertainty"]
         steps = st.multiselect(label="Select steps to perform",
                                options=options,
@@ -55,7 +58,8 @@ if uploaded_file:
                                Photometric: select only scisigpix <= cutoff (default 6) \n
                                Good seeing: select only seeing <= cutoff (default 7) \n
                                Filter procstatus: Exclude listed proc status flags (corresponding to errors) \n
-                               Rescale uncertainty: rescale uncertainty using chisq (Yao et al. 2019)
+                               Rescale uncertainty: rescale uncertainty using chisq (Yao et al. 2019) \n
+                               Correct references: correct the flux of references contaminated by transient flux.
                                """,
                                )
 
@@ -71,7 +75,7 @@ if uploaded_file:
                 lc = lc.remove_bad_pixels([int(p) for p in procstatus])
 
             if "photometric" in steps:
-                defaults = {"g": 6, "r": 6, "i": 9}
+                defaults = {"g": 7, "r": 8, "i": 9}
                 scisigpix_cutoff = st.slider(label="Photometric: scisigpix_cutoff in pixels", min_value=1, max_value=50, value=defaults[band], step=1)
                 lc = lc.photometric(scisigpix_cutoff)
 
@@ -89,10 +93,15 @@ if uploaded_file:
     if _values:
         jd_min, jd_max = _values
 
+    reference_option = st.selectbox("How would you like to deal with references contaminated by transient flux?",
+                                    ("Verify: remove references made with images after my selected jd",
+                                     "Correct: Correct the flux using the nearest object as reference"),
+                                    index=0)
     st.markdown(
-        "### Set baseline and approximate discovery epoch using difference image flux lightcurve and sliders below:")
-    if "verify references" in steps:
-        st.markdown("""<span style="color:yellow">Verify reference JD:</span>""", unsafe_allow_html=True)
+        "### Set baseline and approximate discovery epoch using difference image flux lightcurve and sliders below."
+        "(Discovery epoch only needed if Verifying references instead of Correcting for transient flux.)")
+    if str(reference_option).startswith("Verify"):
+        st.markdown("""<span style="color:yellow">Estimated transient begin JD:</span>""", unsafe_allow_html=True)
         use_baseline = st.button("Set last reference JD to Baseline JD Max", help="click to set last reference JD to Baseline JD Max")
         if st.session_state.get(f"jd_first_{band}"):
             jd_verify = st.session_state.get(f"jd_first_{band}")
@@ -105,6 +114,18 @@ if uploaded_file:
                                    value=float(np.round(jd_verify, 1)), step=0.1, key=f"jd_first_{band}",
                                    help='Everything before this JD will be allowed to be used in the reference.')
         lc = verify_reference(lc, jd_first)
+    elif str(reference_option).startswith("Correct"):
+        st.markdown("Correct reference flux using nearest reference if following parameters are satisfied:")
+
+        sharp_lo, sharp_hi = st.slider(
+            "PSF sharpness low and high cutoffs for nearby reference",
+            -1.0, 1.0, (-0.7, 0.8),
+            step=0.1,
+            help="Ideally, values should be near zero, too high -> extended, too low -> sharp-spike."
+                 "Defaults are good, but may be too lenient."
+        )
+        lc = lc.remove_non_psf_nearest_ref(sharp_hi=sharp_hi, sharp_lo=sharp_lo)
+
 
     st.markdown("""
     <span style="color:cyan">Baseline JD min and max:</span>
@@ -126,18 +147,24 @@ if uploaded_file:
 
     line_min = alt.Chart(lc.to_pandas()).mark_rule(color='cyan').encode(x=alt.datum(jd_min))
     line_max = alt.Chart(lc.to_pandas()).mark_rule(color='cyan').encode(x=alt.datum(jd_max))
-    line_verify = alt.Chart(lc.to_pandas()).mark_rule(color='yellow').encode(x=alt.datum(jd_first))
-    st.altair_chart(chart+line_min+line_max+line_verify, use_container_width=True)
+    if str(reference_option).startswith("Verify"):
+        line_verify = alt.Chart(lc.to_pandas()).mark_rule(color='yellow').encode(x=alt.datum(jd_first))
+        st.altair_chart(chart+line_min+line_max+line_verify, use_container_width=True)
+    st.altair_chart(chart + line_min + line_max, use_container_width=True)
 
     # correct the flux:
     lc["flux_corr"] = lc["forcediffimflux"] - lc.simple_median_baseline(jd_min, jd_max)
-
     st.write("---")
     if "rescale uncertainty" in steps:
         lc.rescale_uncertainty()
         RMS = lc.RMS_baseline(jd_min, jd_max)
         if RMS >= 1.01:
             lc["fluxerr_corr"] = lc["forcediffimfluxunc"] * RMS
+
+    # Get the corrected flux into flux_corr and fluxerr_corr
+    if str(reference_option).startswith("Correct"):
+        st.text("correct!")
+        new_flux, new_err = lc.correct_flux_using_nearest_ref()
 
     col1, col2 = st.columns(2)
     with col1:

--- a/ztfphot/__init__.py
+++ b/ztfphot/__init__.py
@@ -1,4 +1,4 @@
-from .lightcurve import LC, ZTF_LC, verify_reference
+from .lightcurve import LC, ZtfLC, verify_reference
 from .readers import read_ztf_lc
 from .plot_ztffps import make_ztf_lc, plot_and_save_lc
 from .sn import SN

--- a/ztfphot/lightcurve.py
+++ b/ztfphot/lightcurve.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
 from astropy.table import Table
-from astropy.time import Time
-from astropy.timeseries import TimeSeries
 import numpy as np
 from ztfphot.plotting import add_plot
 from abc import ABC, abstractmethod
+import pandas as pd
 
 
 class LC(ABC, Table):
@@ -117,7 +116,7 @@ class ZtfLC(LC):
         errcol = "fluxerr_corr" if "fluxerr_corr" in self.colnames else "forcediffimfluxunc"
 
         nearestrefflux = 10 ** (0.4 * (self.zpdiff - self.nearestrefmag))
-        # self['flux_corr'] = self[fluxcol] + nearestrefflux
+        # lc['flux_corr'] = lc[fluxcol] + nearestrefflux
         corrected_flux = self[fluxcol] + nearestrefflux
 
         nearestreffluxunc = (self.nearestrefmagunc * nearestrefflux) / 1.0857
@@ -128,9 +127,9 @@ class ZtfLC(LC):
         new_err = np.sqrt(self[errcol] ** 2 - nearestreffluxunc ** 2)
         #else:
         #    # More conservative estimate if assumptions not valid
-        #    new_err = np.sqrt(self[errcol] ** 2 + nearestreffluxunc ** 2)
+        #    new_err = np.sqrt(lc[errcol] ** 2 + nearestreffluxunc ** 2)
         #new_err =
-        #self['fluxerr_corr'] = new_err
+        #lc['fluxerr_corr'] = new_err
         return corrected_flux, new_err
 
 
@@ -186,8 +185,62 @@ def verify_reference(at: LC, jd_first: float) -> LC:
     return only_pre
 
 
-def calculate_mag_lc():
-    raise NotImplementedError()
+def remove_non_psf_nearest_ref(lc: ZtfLC, sharp_hi=0.8, sharp_lo=-0.5, nearest_chi_limit: Optional[float] = None) -> LC:
+    """
+    Remove epochs without a suitable PSF nearest reference.
+    nearestrefsharp is a measure of the PSF of the nearest reference. This cleaning
+    should only be done if this value is around 0.
+    Closer to 1 means galaxy/extended-psf, closer to -1 means spike/sharp edge.
+    """
+
+    lc = lc[(lc.nearestrefsharp <= sharp_hi) & (lc.nearestrefsharp >= sharp_lo)]
+    if nearest_chi_limit is not None:
+        lc = lc[lc.nearestrefchi <= nearest_chi_limit]
+    return lc
+
+
+def get_ref_corrected_lc(fluxtot, fluxunctot, zpdiff, SNT: int, SNU: int):
+    SNR_tot = fluxtot / fluxunctot
+    is_limit = SNR_tot < SNT
+
+    mag = zpdiff - 2.5 * np.log10(fluxtot)
+    sigma_mag = 1.0857 / SNR_tot
+
+    lim = zpdiff - 2.5 * np.log10(SNU * fluxunctot)
+    detections = mag[~is_limit]
+    limits = lim[is_limit]
+
+    #sigma_detections = sigma_mag[~is_limit]
+
+    #jd_detections = jd[~is_limit]
+    #jd_limits = jd[is_limit]
+
+    plot_mag = pd.concat((detections, limits), axis=0)
+    plot_err = sigma_mag[(~is_limit) & (sigma_mag <= 1.5)]
+    return plot_mag, plot_err, is_limit, mag, sigma_mag
+    #return detections, sigma_detections, limits, jd_detections, jd_limits
+
+
+def correct_flux_using_nearest_ref(lc: ZtfLC, fluxcol: str, errcol: str):
+    """
+    This is used to correct for reference images contaminated by transient flux.
+    Correct flux using mag of nearest reference, but this should only be done if nearestrefsharp
+    is around 0. Closer to 1 means galaxy, closer to -1 means spike/sharp edge.
+    """
+
+    nearestrefflux = 10 ** (0.4 * (lc.zpdiff - lc.nearestrefmag))
+    # lc['flux_corr'] = lc[fluxcol] + nearestrefflux
+    corrected_flux = lc[fluxcol] + nearestrefflux
+
+    nearestreffluxunc = lc.nearestrefmagunc * nearestrefflux / 1.0857
+
+    corrected_err = np.sqrt(lc[errcol] ** 2 - nearestreffluxunc ** 2)
+    # else:
+    #    # More conservative estimate if assumptions not valid
+    #    new_err = np.sqrt(lc[errcol] ** 2 + nearestreffluxunc ** 2)
+    # new_err =
+    # lc['fluxerr_corr'] = new_err
+    return corrected_flux, corrected_err
 
 
 

--- a/ztfphot/plot_ztffps.py
+++ b/ztfphot/plot_ztffps.py
@@ -2,7 +2,7 @@ from typing import Optional
 import matplotlib.pyplot as plt
 import pandas as pd
 from ztfphot.plotting import PlotType
-from ztfphot.lightcurve import ZTF_LC, LC, verify_reference
+from ztfphot.lightcurve import ZtfLC, LC, verify_reference
 from ztfphot.readers import read_ztf_lc
 from ztfphot.sn import SN
 
@@ -11,14 +11,14 @@ INPUTDIR = "tests/input/"
 OUTPUTDIR = "tests/output/"
 
 
-def make_ztf_lc(sn: SN, verify_references: bool = False) -> ZTF_LC:
+def make_ztf_lc(sn: SN, verify_references: bool = False) -> ZtfLC:
     fpath = sn.filename
     jd_first = sn.jd_first_epoch
     at = read_ztf_lc(fpath)
     if jd_first is not None and verify_references:
         at = verify_reference(at, jd_first)  # Remove references contaminated by the object
 
-    lc = ZTF_LC(at)
+    lc = ZtfLC(at)
     lc.clean_lc(scisigpix_cutoff=25)
     return lc
 
@@ -53,7 +53,7 @@ def main():
 
     plt.ion()
     phases = pd.read_json(INPUTDIR + "phase_epochs.json", typ="Series")
-    SN2020lao = SN(
+    sn2020lao = SN(
         jd_first_epoch=phases.discovery - 2,
         jd_min=2458840.0,
         jd_max=2458989.0,
@@ -61,15 +61,15 @@ def main():
         filename=INPUTDIR + "forcedphotometry_req00104849_lc.txt",
     )
 
-    SN2018ebt = SN(
+    sn2018ebt = SN(
         jd_first_epoch=2458323,
         jd_min=2458190,
         jd_max=2458313,
         snname="SN2018ebt",
         filename=INPUTDIR + "forcedphotometry_req00108452_lc.txt",
     )
-    lc = make_ztf_lc(SN2020lao, verify_references=True)
-    sn2020lao_lc = plot_and_save_lc(SN2020lao, lc)
+    lc = make_ztf_lc(sn2020lao, verify_references=True)
+    sn2020lao_lc = plot_and_save_lc(sn2020lao, lc)
     plt.show(block=True)
     return sn2020lao_lc
 

--- a/ztfphot/readers.py
+++ b/ztfphot/readers.py
@@ -47,6 +47,9 @@ def convert_to_numeric(at: Table) -> Table:
         "forcediffimfluxuncap",
         "forcediffimsnrap",
         "aperturecorr",
+        "nearestrefsharp",
+        "nearestrefflux",
+        "nearestrefchi",
     ]
     for col in force_cols:
         at[col] = to_numeric(at[col])


### PR DESCRIPTION
Adds correction for reference contaminated by reference flux using nearest reference psf, if the PSF is appropriately sharp (point-like) and has a suitable chisq. 

This method may produce lightcurves that are slightly too bright when the flux gets near the detection limit.